### PR TITLE
ci: switch to Mic92/hestia@v1

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: Mic92/hestia/action@v1
+      - uses: Mic92/hestia@v1
         with:
           version: v1
 
@@ -83,7 +83,7 @@ jobs:
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: Mic92/hestia/action@v1
+      - uses: Mic92/hestia@v1
         with:
           version: v1
 

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: Mic92/hestia/action@v1
+      - uses: Mic92/hestia@v1
         with:
           version: v1
 


### PR DESCRIPTION
Hestia [v1.0](https://github.com/Mic92/hestia/releases/tag/v1.0.2) moved `action.yml` to the repo root, so the path shortens from `Mic92/hestia/action@...` to `Mic92/hestia@v1`. Tracking the floating major tag keeps CI on the latest compatible 1.x release; the old subpath still works for backward compatibility, this is just a cleanup.